### PR TITLE
fix extension support, by selecting all enabled extensions

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -17,7 +17,7 @@ module Main (main) where
 import Data.List (isPrefixOf, partition)
 import Data.Vector(Vector, fromList)
 import Language.Haskell.Exts.Annotated (parseFileContentsWithMode, ParseMode(..), knownExtensions, ParseResult(ParseOk, ParseFailed))
-import Language.Haskell.Exts.Extension (Language(..))
+import Language.Haskell.Exts.Extension (Language(..), Extension(EnableExtension, DisableExtension))
 import System.Environment (getArgs, getProgName)
 import System.IO (hPutStrLn, stderr)
 import qualified Data.Text as T (unpack, lines, pack, unlines)
@@ -55,12 +55,14 @@ processFile file ignore_parse_error = do
         parseMode = ParseMode
             { parseFilename = file
             , baseLanguage = Haskell2010
-            , extensions = knownExtensions
+            , extensions = filter isEnabled knownExtensions
             , ignoreLanguagePragmas = False
             , ignoreLinePragmas = True
             , fixities = Nothing
             , ignoreFunctionArity = False
             }
+        isEnabled (EnableExtension _) = True
+        isEnabled _ = False
 
 loadFile :: FilePath -> IO (String, Vector String)
 loadFile file = do


### PR DESCRIPTION
As per https://github.com/bitc/lushtags/issues/34.

`knownExtensions` actually returns a list of all extensions in both enabled and
disabled form. We only want the parser to care about the enabled ones, otherwise
they don't actually get enabled.